### PR TITLE
WIP: Add support for '--build-reqs' in the pip commands

### DIFF
--- a/pip_run/tests/test_deps.py
+++ b/pip_run/tests/test_deps.py
@@ -1,4 +1,5 @@
 import copy
+import textwrap
 
 import pkg_resources
 
@@ -54,3 +55,18 @@ class TestLoad:
 		"""
 		with deps.load('-q'):
 			pass
+
+
+class TestReplaceBuildDeps:
+	def test_requirements_built(self, tmpdir):
+		target = tmpdir / 'build-reqs.txt'
+		pip_args = ('--build-reqs', 'pyproject.toml')
+		replaced = deps.replace_build_deps(pip_args, str(tmpdir))
+		expected = '--requirement', str(target)
+		assert replaced == expected
+		with target.open() as strm:
+			assert strm.read() == textwrap.dedent("""
+				setuptools>=34.4
+				wheel
+				setuptools_scm>=1.15
+				""").lstrip()

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,9 @@ packages = find:
 include_package_data = true
 py_modules = pip-run
 python_requires = >=2.7
-install_requires = pip
+install_requires =
+	pip
+	pytoml
 setup_requires = setuptools_scm >= 1.15.0
 
 [options.extras_require]


### PR DESCRIPTION
Add support for '--build-reqs' in the pip commands to parse out a pyproject.toml and include those dependencies in the run. Fixes #33.

This proof-of-concept demonstrates how one might hack in support for parsing a pyproject.toml's build-system.requires into a standard pip requirements.txt.