### PR TITLE
Remove dependency links

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,15 @@
+v6.1.0
+------
+
+* semver deviation *
+
+#41: Removed support for ``__dependency_links__``
+in scripts. Instead, use `PEP 508
+<https://www.python.org/dev/peps/pep-0508/>`_ syntax.
+For example, to run a script requiring requests at master::
+
+    __requires__ = ['requests @ git+https://github.com/requests/requests']
+
 v6.0.0
 ------
 

--- a/README.rst
+++ b/README.rst
@@ -180,17 +180,6 @@ Then, simply invoke that script with pip-run::
 
 The format for requirements must follow `PEP 508 <https://www.python.org/dev/peps/pep-0508/>`_.
 
-Note that URLs specifiers are not supported by pip, but ``pip-run`` supports a
-global ``__dependency_links__`` attribute which can be used, for example, to
-install requirement from a project VCS URL::
-
-    #!/usr/bin/env python
-
-    __requires__ = ['foo==0.42']
-    __dependency_links__ = ['git+ssh://git@example.com/repo.git#egg=foo-0.42']
-
-    [...]
-
 ``pip-run`` also recognizes a global ``__index_url__`` attribute. If present,
 this value will supply ``--index-url`` to pip with the attribute value,
 allowing a script to specify a custom package index::

--- a/pip_run/scripts.py
+++ b/pip_run/scripts.py
@@ -20,12 +20,9 @@ if sys.version_info < (3,):
 
 class Dependencies(list):
     index_url = None
-    dependency_links = []
 
     def params(self):
         prefix = ['--index-url', self.index_url] if self.index_url else []
-        for link in self.dependency_links:
-            prefix.extend(['--find-links', link])
         return prefix + self
 
 
@@ -79,12 +76,6 @@ class DepsReader:
             deps.index_url = self._read('__index_url__')
         except Exception:
             pass
-        try:
-            raw_links = self._read('__dependency_links__')
-        except Exception:
-            pass
-        else:
-            deps.dependency_links = list(pkg_resources.yield_lines(raw_links))
         return deps
 
     def _read(self, var_name):

--- a/pip_run/tests/test_scripts.py
+++ b/pip_run/tests/test_scripts.py
@@ -64,18 +64,6 @@ class TestDepsReader:
         reqs = scripts.DepsReader(script).read()
         assert reqs.index_url == 'https://my.private.index/'
 
-    def test_dependency_links(self):
-        script = textwrap.dedent(
-            '''
-            __requires__ = ['foo==0.42']
-            __dependency_links__ = ['git+ssh://git@example.com/repo.git#egg=foo-0.42']
-            '''
-        )
-        reqs = scripts.DepsReader(script).read()
-        assert reqs.dependency_links == [
-            'git+ssh://git@example.com/repo.git#egg=foo-0.42'
-        ]
-
     def test_fstrings_allowed(self):
         """
         It should be possible to read dependencies from a script
@@ -115,10 +103,10 @@ def test_pkg_loaded_from_alternate_index(tmpdir):
     assert 'devpi.net' in out
 
 
-def test_pkg_loaded_from_dependency_links(tmpdir):
+def test_pkg_loaded_from_url(tmpdir):
     """
     Create a script whose dependency is only installable
-    from a custom dependency link and ensure it runs.
+    from a custom url and ensure it runs.
     """
     dependency = tmpdir.ensure_dir('barbazquux-1.0')
     (dependency / 'setup.py').write_text(
@@ -140,8 +128,7 @@ def test_pkg_loaded_from_dependency_links(tmpdir):
     body = (
         textwrap.dedent(
             """
-        __requires__ = ['barbazquux']
-        __dependency_links__ = [{dependency_link!r}]
+        __requires__ = [{dependency_link!r}]
         import barbazquux
         print("Successfully imported barbazquux.py")
         """

--- a/pip_run/tests/test_scripts.py
+++ b/pip_run/tests/test_scripts.py
@@ -122,19 +122,17 @@ def test_pkg_loaded_from_url(tmpdir):
         'utf-8',
     )
     (dependency / 'barbazquux.py').write_text('', 'utf-8')
-    dependency_link = 'file://%s#egg=barbazquux-1.0' % (
-        dependency.strpath.replace(os.path.sep, '/'),
-    )
+    url_req = 'barbazquux @ file://%s' % (dependency.strpath.replace(os.path.sep, '/'),)
     body = (
         textwrap.dedent(
             """
-        __requires__ = [{dependency_link!r}]
+        __requires__ = [{url_req!r}]
         import barbazquux
         print("Successfully imported barbazquux.py")
         """
         )
         .lstrip()
-        .format(dependency_link=dependency_link)
+        .format(**locals())
     )
     script_file = tmpdir.ensure_dir('script_dir') / 'script'
     script_file.write_text(body, 'utf-8')


### PR DESCRIPTION
This change essentially reverts #24, while retaining the functional test illustrating recommended usage for URL-based specifiers without dependency links.

@benoit-pierre Does this approach satisfy the use-cases that led to #24?