### PR TITLE
Ensure read-deps errors when the specified script does not exist.

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,8 @@
+v8.3.0
+======
+
+#47: ``read_deps`` now errors on non-existent files.
+
 v8.2.1
 ======
 

--- a/pip_run/read-deps.py
+++ b/pip_run/read-deps.py
@@ -2,7 +2,7 @@
 Emit parameters to pip extracted from a script.
 """
 
-import os
+import pathlib
 
 import autocommand
 
@@ -11,7 +11,7 @@ from .scripts import DepsReader
 
 class ExtantFile(str):
     def __init__(self, value):
-        if not os.path.isfile(value):
+        if not pathlib.Path(value).is_file():
             raise FileNotFoundError(f"{value} does not exist.")
 
 

--- a/pip_run/read-deps.py
+++ b/pip_run/read-deps.py
@@ -2,19 +2,26 @@
 Emit parameters to pip extracted from a script.
 """
 
-import sys
+import os
+
+import autocommand
 
 from .scripts import DepsReader
 
 
-def run(args=None):
+class ExtantFile(str):
+    def __init__(self, value):
+        if not os.path.isfile(value):
+            raise FileNotFoundError(f"{value} does not exist.")
+
+
+@autocommand.autocommand(__name__)
+def run(script: ExtantFile):
     """
     >>> run(['examples/test-mongodb-covered-query.py'])
     pytest jaraco.mongodb>=3.10
+    >>> run(['does-not-exist'])
+    Traceback (most recent call last):
+    FileNotFoundError: does-not-exist does not exist.
     """
-    (script,) = args or sys.argv[1:]
-    deps = DepsReader.try_read(script)
-    print(' '.join(deps.params()))
-
-
-__name__ == '__main__' and run()
+    print(' '.join(DepsReader.try_read(script).params()))

--- a/pip_run/read-deps.py
+++ b/pip_run/read-deps.py
@@ -2,26 +2,19 @@
 Emit parameters to pip extracted from a script.
 """
 
-import pathlib
-
 import autocommand
+import path
 
 from .scripts import DepsReader
 
 
-class ExtantFile(str):
-    def __init__(self, value):
-        if not pathlib.Path(value).is_file():
-            raise FileNotFoundError(f"{value} does not exist.")
-
-
 @autocommand.autocommand(__name__)
-def run(script: ExtantFile):
+def run(script: path.ExtantFile):
     """
     >>> run(['examples/test-mongodb-covered-query.py'])
     pytest jaraco.mongodb>=3.10
     >>> run(['does-not-exist'])
     Traceback (most recent call last):
-    FileNotFoundError: does-not-exist does not exist.
+    FileNotFoundError: does-not-exist does not exist as a file.
     """
     print(' '.join(DepsReader.try_read(script).params()))

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,9 @@ packages = find_namespace:
 include_package_data = true
 py_modules = pip-run
 python_requires = >=3.6
-install_requires = pip >= 19.3
+install_requires =
+	pip >= 19.3
+	autocommand
 setup_requires = setuptools_scm[toml] >= 3.4.1
 
 [options.packages.find]

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,6 +22,7 @@ python_requires = >=3.6
 install_requires =
 	pip >= 19.3
 	autocommand
+	path >= 15.1
 setup_requires = setuptools_scm[toml] >= 3.4.1
 
 [options.packages.find]


### PR DESCRIPTION
Closes #47.

I'm not releasing this right away because I want to mull it over a bit. Adding the dependency is undesirable, but makes the code mostly elegant.