### PR TITLE
Add detection for scripts by shebang line

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -75,7 +75,7 @@ Usage
 - as runtime dependency context manager
 - as interactive interpreter in dependency context
 - as module launcher (akin to `python -m`)
-- as a shell shebang (``#!/usr/bin/env -S pip-run --``), to create single-file Python tools
+- as a shell shebang (``#!/usr/bin/env pip-run``), to create single-file Python tools
 
 Invoke ``pip-run`` from the command-line using the console entry
 script (simply ``pip-run``) or using the module executable (
@@ -234,7 +234,7 @@ as ``pip-run`` is installed on the system ``PATH``.
 
 .. code-block:: shell
 
-    #!/usr/bin/env -S pip-run --
+    #!/usr/bin/env pip-run
     __requires__ = ['requests', 'beautifulsoup4', 'cowsay']
     import requests
     from bs4 import BeautifulSoup as BS
@@ -244,8 +244,6 @@ as ``pip-run`` is installed on the system ``PATH``.
     cowsay.dragon(b.find("div", class_="introduction").get_text())
 
 Executing this script, when saved as ``myscript``, is equivalent to ``pip-run -- myscript``.
-``-S`` and ``--`` ensure that extension-less scripts (like ``myscript`` rather than ``myscript.py``)
-will be correctly identified as a script (rather than as a dependency), so don't forget them.
 
 By default, ``pip-run`` will re-install dependencies every time a script runs.
 This silently adds a variable amount of startup time depending on how many dependencies
@@ -253,7 +251,7 @@ there are (use ``pip-run -v -- myscript`` to see the list). A script may cache t
 installs via `Environment Persistence <#Environment-Persistence>`_ by setting
 ``PIP_RUN_MODE=persist``::
 
-    #!/usr/bin/env -S PIP_RUN_MODE=persist pip-run --
+    #!/usr/bin/env PIP_RUN_MODE=persist pip-run
     ...
 
 Other Script Directives

--- a/newsfragments/78.feature.rst
+++ b/newsfragments/78.feature.rst
@@ -1,0 +1,1 @@
+Presence of Python script parameters now honors files with a shebang even if no Python extension is present.

--- a/pip_run/commands.py
+++ b/pip_run/commands.py
@@ -16,15 +16,7 @@ def _is_python_arg(item: str):
     to Python and not to pip install.
     """
     path = pathlib.Path(item)
-    # start with the tests which do very minimal IO
-    if not path.exists():
-        return False
-    if path.suffix == ".py":
-        return True
-
-    # now, sniff the first line of the file and return true if it looks like
-    # a script
-    return _has_shebang(path)
+    return path.is_file() and (path.suffix == '.py' or _has_shebang(path))
 
 
 @suppress(UnicodeDecodeError)

--- a/pip_run/commands.py
+++ b/pip_run/commands.py
@@ -1,4 +1,3 @@
-import codecs
 import pathlib
 import contextlib
 import argparse
@@ -6,6 +5,7 @@ import argparse
 from more_itertools import locate, split_at
 from jaraco.functools import bypass_when
 from jaraco import env  # type: ignore # (python/mypy#15970)
+from jaraco.context import suppress
 
 from ._py38compat import files
 
@@ -27,22 +27,11 @@ def _is_python_arg(item: str):
     return _has_shebang(path)
 
 
+@suppress(UnicodeDecodeError)
 def _has_shebang(path: pathlib.Path) -> bool:
-    with path.open('rb') as fp:
-        first_line = _strip_bom(fp.readline())
-    return first_line.startswith(b"#!")
-
-
-def _strip_bom(byte_str: bytes) -> bytes:
-    # UTF-8
-    if byte_str.startswith(codecs.BOM_UTF8):
-        return byte_str[len(codecs.BOM_UTF8) :]
-    # UTF-16
-    if byte_str.startswith(codecs.BOM_LE):
-        return byte_str[len(codecs.BOM_LE) :]
-    if byte_str.startswith(codecs.BOM_BE):
-        return byte_str[len(codecs.BOM_BE) :]
-    return byte_str
+    with path.open(encoding='utf-8-sig') as fp:
+        first_line = fp.readline()
+    return first_line.startswith("#!")
 
 
 def _separate_script(args):

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,31 +1,41 @@
-import codecs
-
 import pytest
 
 from pip_run import commands
 
 
-@pytest.mark.parametrize(
-    "shebang, expect_success",
-    [
-        # simple cases
-        (b"#!/usr/bin/env python", True),
-        (b"#!/usr/bin/env -S pip-run", True),
-        (b"#!/usr/bin/python -W error", True),
-        (b"#/usr/bin/env python", False),
-        (b"!/usr/bin/env python", False),
-        # invalid start byte (not BOM)
-        (b"\xf1#!/usr/bin/env -S python", False),
-        # valid BOM start bytes
-        (codecs.BOM_UTF8 + b"#!/usr/bin/env -S python", True),
-        # invalid start sequence (BOM appears multiple times)
-        (codecs.BOM_UTF8 + codecs.BOM_UTF8 + b"#!/usr/bin/env -S python", False),
-    ],
-)
-def test_shebang_line_detection(tmp_path, shebang, expect_success):
+valid_shebangs = [
+    '#!/usr/bin/env python',
+    '#!/usr/bin/env -S pip-run',
+    '#!/usr/bin/python -W error',
+    # with BOM
+    '#!/usr/bin/env -S python'.encode('utf-8-sig').decode('utf-8'),
+]
+
+invalid_shebangs = [
+    '#/usr/bin/env python',
+    '!/usr/bin/env python',
+]
+
+
+@pytest.mark.parametrize('shebang', valid_shebangs)
+def test_shebang_detected(tmp_path, shebang):
     script = tmp_path / 'script'
-    script.write_bytes(shebang + b'\nprint("Hello world!")')
-    if expect_success:
-        assert commands._has_shebang(script)
-    else:
-        assert not commands._has_shebang(script)
+    script.write_text(f'{shebang}\nprint("Hello world!")', encoding='utf-8')
+    assert commands._has_shebang(script)
+
+
+@pytest.mark.parametrize('shebang', invalid_shebangs)
+def test_shebang_not_detected(tmp_path, shebang):
+    script = tmp_path / 'script'
+    script.write_text(f'{shebang}\nprint("Hello world!")', encoding='utf-8')
+    assert not commands._has_shebang(script)
+
+
+def test_shebang_invalid_encoding(tmp_path):
+    """
+    If the script cannot be decoded in UTF-8, value should be false.
+    """
+    script = tmp_path / 'script'
+    shebang = '\xf1#!/usr/bin/env -S python'
+    script.write_text(f'{shebang}\nprint("Hello world!")', encoding='latin-1')
+    assert not commands._has_shebang(script)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,0 +1,33 @@
+import codecs
+
+import pytest
+
+from pip_run import commands
+
+
+@pytest.mark.parametrize(
+    "shebang, expect_success",
+    [
+        # simple cases
+        (b"#!/usr/bin/env python", True),
+        (b"#!/usr/bin/env -S pip-run", True),
+        (b"#!/usr/bin/python -W error", True),
+        (b"#/usr/bin/env python", False),
+        (b"!/usr/bin/env python", False),
+        # invalid start byte (not BOM)
+        (b"\xf1#!/usr/bin/env -S python", False),
+        # valid BOM start bytes
+        (codecs.BOM_UTF8 + b"#!/usr/bin/env -S python", True),
+        (codecs.BOM_LE + b"#!/usr/bin/env -S python", True),
+        (codecs.BOM_BE + b"#!/usr/bin/env -S python", True),
+        # invalid start sequence (BOM appears multiple times)
+        (codecs.BOM_UTF8 + codecs.BOM_UTF8 + b"#!/usr/bin/env -S python", False),
+    ],
+)
+def test_shebang_line_detection(tmp_path, shebang, expect_success):
+    script = tmp_path / 'script'
+    script.write_bytes(shebang + b'\nprint("Hello world!")')
+    if expect_success:
+        assert commands._has_shebang(script)
+    else:
+        assert not commands._has_shebang(script)

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -18,8 +18,6 @@ from pip_run import commands
         (b"\xf1#!/usr/bin/env -S python", False),
         # valid BOM start bytes
         (codecs.BOM_UTF8 + b"#!/usr/bin/env -S python", True),
-        (codecs.BOM_LE + b"#!/usr/bin/env -S python", True),
-        (codecs.BOM_BE + b"#!/usr/bin/env -S python", True),
         # invalid start sequence (BOM appears multiple times)
         (codecs.BOM_UTF8 + codecs.BOM_UTF8 + b"#!/usr/bin/env -S python", False),
     ],

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -1,4 +1,3 @@
-import codecs
 import textwrap
 import sys
 import subprocess
@@ -8,7 +7,6 @@ import nbformat
 import jaraco.path
 
 from pip_run import scripts
-from pip_run.commands import _has_shebang
 
 
 def DALS(str):
@@ -264,31 +262,3 @@ def test_pkg_loaded_from_url(tmp_path):
     ]
     out = subprocess.check_output(cmd, text=True, encoding='utf-8')
     assert 'Successfully imported barbazquux' in out
-
-
-@pytest.mark.parametrize(
-    "shebang, expect_success",
-    [
-        # simple cases
-        (b"#!/usr/bin/env python", True),
-        (b"#!/usr/bin/env -S pip-run", True),
-        (b"#!/usr/bin/python -W error", True),
-        (b"#/usr/bin/env python", False),
-        (b"!/usr/bin/env python", False),
-        # invalid start byte (not BOM)
-        (b"\xf1#!/usr/bin/env -S python", False),
-        # valid BOM start bytes
-        (codecs.BOM_UTF8 + b"#!/usr/bin/env -S python", True),
-        (codecs.BOM_LE + b"#!/usr/bin/env -S python", True),
-        (codecs.BOM_BE + b"#!/usr/bin/env -S python", True),
-        # invalid start sequence (BOM appears multiple times)
-        (codecs.BOM_UTF8 + codecs.BOM_UTF8 + b"#!/usr/bin/env -S python", False),
-    ],
-)
-def test_shebang_line_detection(tmp_path, shebang, expect_success):
-    script = tmp_path / 'script'
-    script.write_bytes(shebang + b'\nprint("Hello world!")')
-    if expect_success:
-        assert _has_shebang(script)
-    else:
-        assert not _has_shebang(script)


### PR DESCRIPTION
To detect if the first argument is a script file, the previous rules are checked first: an existing file with a `.py` suffix always passes.

If that check fails but the file exists, the next stage is now to check the shebang line and allow for any script which is a direct or `/usr/bin/env` invocation of the following commands:
- python
- python3
- pip-run
- py
- pypy
- pypy3
- python3.*

`env -S` is allowed as well, as it may be used to pass additional arguments to the underlying command.

A small amount of extra care is taken around handling invalid unicode content. The first line is the only line which is decoded, and any decoding error makes the shebang check fail.

Unit tests confirm the shebang line parsing behavior outside of the broader context of `pip-run` invocations.

---

I think that we can comfortably say that this PR resolves #78.
The biggest question mark here is how much testing to do, and of what kind. I'm happy to pursue more tests, but the initial set of unit tests cover what I think are the most essential cases.