### PR TITLE
Fix funding link

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,1 +1,1 @@
-tidelift: pypi/PROJECT
+tidelift: pypi/pip-run


### PR DESCRIPTION
I think it was supposed to be [`pypi/pip-run`](https://tidelift.com/funding/github/pypi/pip-run), not [`pypi/PROJECT`](https://tidelift.com/funding/github/pypi/PROJECT). Looks like a change from [jaraco/skeleton](https://github.com/jaraco/skeleton)(?) that wasn't substituted with the right value in propagation.
I think I saw similar broken links in some other skeleton downstream projects, I will check.