### PR TITLE
Support reading annotated variables.

### DIFF
--- a/newsfragments/102.bugfix.rst
+++ b/newsfragments/102.bugfix.rst
@@ -1,0 +1,1 @@
+Support reading annotated variables (e.g. `__requires__: list[str] = ["jaraco.functools"]`).

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -73,6 +73,31 @@ class TestSourceDepsReader:
         )
         assert scripts.DepsReader(script).read() == ['foo']
 
+    def test_single_annotated_dep(self):
+        script = textwrap.dedent(
+            """
+            __requires__:str='foo'
+            """
+        )
+        assert scripts.DepsReader(script).read() == ['foo']
+
+    def test_multiple_annotated_deps(self):
+        script = textwrap.dedent(
+            """
+            __requires__:list[str]=['foo']
+            """
+        )
+        assert scripts.DepsReader(script).read() == ['foo']
+
+    def test_skips_on_ambiguity(self):
+        script = textwrap.dedent(
+            """
+            __requires__:list[str]=['foo']
+            __requires__='bar'
+            """
+        )
+        assert scripts.DepsReader(script).read() == []
+
     def test_index_url(self):
         script = textwrap.dedent(
             """

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -84,10 +84,10 @@ class TestSourceDepsReader:
     def test_multiple_annotated_deps(self):
         script = textwrap.dedent(
             """
-            __requires__:list[str]=['foo']
+            __requires__:list[str]=['foo', 'bar']
             """
         )
-        assert scripts.DepsReader(script).read() == ['foo']
+        assert scripts.DepsReader(script).read() == ['foo', 'bar']
 
     def test_skips_on_ambiguity(self):
         script = textwrap.dedent(


### PR DESCRIPTION
Adds support for reading `__requires__` and `__index_url__` variables if they are annotated and preserves the behavior of recognizing no dependencies in case of ambiguity (multiple definitions of the same variable in the same indent level).
Since this change, the `DepsReader._read` method is safe and requires no outer exception handling when used.