### PR TITLE
Drop support for filtering out satisfied requirements.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,7 +47,6 @@ Features include
 - Relies on pip to cache downloads of such packages for reuse.
 - Leaves no trace of its invocation (except files in pip's cache).
 - Supersedes installed packages when required.
-- Relies on packages already satisfied [1]_.
 - Re-uses the pip tool chain for package installation.
 
 ``pip-run`` is not intended to solve production dependency management, but does aim to address the other, one-off scenarios around dependency management:
@@ -61,8 +60,6 @@ Features include
 
 ``pip-run`` is a complement to Pip and Virtualenv, intended to more
 readily address the on-demand needs.
-
-.. [1] Except when a requirements file is used.
 
 Installation
 ============
@@ -409,9 +406,6 @@ runpy scripts).
      - ✓
      -
    * - interactive interpreter with deps
-     - ✓
-     -
-   * - re-use existing environment
      - ✓
      -
    * - ephemeral environments

--- a/newsfragments/51.removal.rst
+++ b/newsfragments/51.removal.rst
@@ -1,0 +1,1 @@
+Dropped support for filtering out satisfied requirements.

--- a/pip_run/__init__.py
+++ b/pip_run/__init__.py
@@ -10,5 +10,5 @@ def run(args=sys.argv[1:]):
     pip_args, run_args = commands.infer_ipython(commands.separate(args))
     commands.intercept(pip_args)
     pip_args.extend(scripts.DepsReader.search(run_args))
-    with deps.load(*deps.not_installed(pip_args)) as home:
+    with deps.load(*pip_args) as home:
         raise SystemExit(launch.with_path(home, launch.infer_cmd(run_args)))

--- a/pip_run/deps.py
+++ b/pip_run/deps.py
@@ -1,17 +1,13 @@
 import argparse
 import contextlib
-import functools
 import importlib
-import itertools
 import os
 import pathlib
 import subprocess
 import sys
 import types
 import warnings
-from importlib import metadata
 
-import packaging.requirements
 from jaraco.context import suppress
 
 from .compat.py38 import subprocess_path as sp
@@ -108,15 +104,3 @@ def with_prereleases(spec):
     """
     spec.prereleases = True
     return spec
-
-
-@suppress(
-    packaging.requirements.InvalidRequirement,
-    metadata.PackageNotFoundError,  # type: ignore
-)
-def pkg_installed(spec):
-    req = packaging.requirements.Requirement(spec)
-    return not req.url and metadata.version(req.name) in with_prereleases(req.specifier)
-
-
-not_installed = functools.partial(itertools.filterfalse, pkg_installed)

--- a/tests/test_deps.py
+++ b/tests/test_deps.py
@@ -1,34 +1,6 @@
-import copy
-
 import pytest
 
 import pip_run.deps as deps
-
-
-class TestInstallCheck:
-    def test_installed(self):
-        assert deps.pkg_installed('pip-run')
-
-    def test_not_installed(self):
-        assert not deps.pkg_installed('not_a_package')
-
-    def test_installed_version(self):
-        assert not deps.pkg_installed('pip-run==0.0')
-
-    def test_not_installed_args(self):
-        args = [
-            '-i',
-            'https://devpi.net',
-            '-r',
-            'requirements.txt',
-            'pip-run',
-            'not_a_package',
-            'pip-run==0.0',
-        ]
-        expected = copy.copy(args)
-        expected.remove('pip-run')
-        filtered = deps.not_installed(args)
-        assert list(filtered) == expected
 
 
 @pytest.mark.usefixtures('retention_strategy')
@@ -55,7 +27,3 @@ def test_target_retention_context():
     """Verify a target exists or can be created."""
     with deps.retention_strategy().context([]) as target:
         target.mkdir(exist_ok=True)
-
-
-def test_url_req_never_installed():
-    assert not deps.pkg_installed('pip_run @git+https://github.com/jaraco/pip-run')


### PR DESCRIPTION
This approach was a performance optimization and intended as a means to augment an existing environment and avoid re-installing packages that were already satisfied. This behavior contradicts the efforts in #104 to run independent of the environment in which pip-run is installed.

Closes #51.
