### PR TITLE
Allow for and prefer uv installer if present

### DIFF
--- a/newsfragments/100.removal.rst
+++ b/newsfragments/100.removal.rst
@@ -1,0 +1,1 @@
+Now supports and prefers uv as the installer if present. Now either 'uv' or 'pip' must be installed as commands. 'pip' has been removed as a dependency.

--- a/pip_run/deps.py
+++ b/pip_run/deps.py
@@ -91,7 +91,6 @@ def installer(target):
     scheme = installer_schemes[next(filter(shutil.which, installer_schemes))]
     return scheme.cmd + [
         'install',
-        '--quiet',
         '--python',
         sys.executable,
         '--target',
@@ -99,10 +98,49 @@ def installer(target):
     ]
 
 
+def default_quiet(cmd):
+    """
+    Parse command to determine the verbosity, then make it one bit quieter.
+
+    Workaround for astral-sh/uv#12397.
+    """
+
+    class Subtract(argparse.Action):
+        def __call__(self, parser, namespace, values, option_string=None):
+            namespace.__dict__[self.dest] -= 1
+
+    parser = argparse.ArgumentParser(description="Control verbosity.")
+
+    parser.add_argument(
+        '-q',
+        '--quiet',
+        action=Subtract,
+        dest='verbosity',
+        default=0,
+        nargs=0,
+        help='Decrease verbosity (can be specified multiple times).',
+    )
+
+    parser.add_argument(
+        '-v',
+        '--verbose',
+        action='count',
+        dest='verbosity',
+        default=0,
+        help='Increase verbosity (can be specified multiple times).',
+    )
+    parsed, unused = parser.parse_known_args(cmd)
+
+    # set the verbosity to one level lower than indicated and never lower than -1
+    verbosity = max(parsed.verbosity - 1, -1)
+
+    return unused + ['--quiet'] * -verbosity + ['--verbose'] * verbosity
+
+
 @contextlib.contextmanager
 def load(*args):
     with retention_strategy().context(args) as target:
-        cmd = tuple(installer(sp(target))) + args
+        cmd = list(installer(sp(target))) + default_quiet(args)
         if Install.parse(args) and empty(target):
             subprocess.check_call(cmd)
         yield target

--- a/pip_run/deps.py
+++ b/pip_run/deps.py
@@ -89,14 +89,20 @@ installer_schemes = dict(
 
 def installer(target):
     scheme = installer_schemes[next(filter(shutil.which, installer_schemes))]
-    return scheme.cmd + ['install', '--python', sys.executable, '--target', target]
+    return scheme.cmd + [
+        'install',
+        '--quiet',
+        '--python',
+        sys.executable,
+        '--target',
+        target,
+    ]
 
 
 @contextlib.contextmanager
 def load(*args):
     with retention_strategy().context(args) as target:
         cmd = tuple(installer(sp(target))) + args
-        env = dict(os.environ, PIP_QUIET="1")
         if Install.parse(args) and empty(target):
-            subprocess.check_call(cmd, env=env)
+            subprocess.check_call(cmd)
         yield target

--- a/pip_run/deps.py
+++ b/pip_run/deps.py
@@ -79,10 +79,10 @@ def empty(path):
 
 installer_schemes = dict(
     uv=types.SimpleNamespace(
-        cmd=['uv', 'pip'],
+        cmd=['uv', 'pip', 'install', '--python', sys.executable],
     ),
     pip=types.SimpleNamespace(
-        cmd=['pip'],
+        cmd=['pip', '--python', sys.executable, 'install'],
     ),
 )
 
@@ -90,9 +90,6 @@ installer_schemes = dict(
 def installer(target):
     scheme = installer_schemes[next(filter(shutil.which, installer_schemes))]
     return scheme.cmd + [
-        'install',
-        '--python',
-        sys.executable,
         '--target',
         target,
     ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,6 @@ classifiers = [
 ]
 requires-python = ">=3.9"
 dependencies = [
-	"pip >= 19.3",
 	"autocommand",
 	"path >= 15.1",
 	"packaging",

--- a/tests/test_scripts.py
+++ b/tests/test_scripts.py
@@ -7,7 +7,7 @@ import jaraco.path
 import nbformat
 import pytest
 
-from pip_run import scripts
+from pip_run import deps, scripts
 
 
 def DALS(str):
@@ -181,7 +181,9 @@ def test_pkg_loaded_from_alternate_index(tmp_path):
 
     out = subprocess.check_output(cmd, text=True, encoding='utf-8')
     assert 'Import succeeded' in out
-    assert 'devpi.net' in out
+    if deps.installer(None)[0] == 'pip':
+        # uv won't emit the index
+        assert 'devpi.net' in out
 
 
 def _minimal_flit(name):


### PR DESCRIPTION
- **Add support for and prefer uv for installation.**
- **Move the '--quiet' indication into the command args for UV to honor it.**
- **Parse out quiet and verbosity parameters.**
- **Disable the output check on uv.**
- **Remove dependency on pip.**
- **Add news fragment.**
