### PR TITLE
Fix FileNotFoundError when cache directory doesn't exist on macOS

### DIFF
--- a/pip_run/retention/persist.py
+++ b/pip_run/retention/persist.py
@@ -50,4 +50,6 @@ def cache_key(args):
 
 @contextlib.contextmanager
 def context(args):
-    yield paths.user_cache_path.joinpath(cache_key(args))
+    target = paths.user_cache_path.joinpath(cache_key(args))
+    target.mkdir(parents=True, exist_ok=True)
+    yield target


### PR DESCRIPTION
I am not sure how this relates to #68 but on the latest publish version and main, I get this error on macOS (on linux, it works fine):

```
Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/Users/<username>/Sync/pip-run/pip_run/__main__.py", line 3, in <module>
    __name__ == '__main__' and run()
                               ~~~^^
  File "/Users/<username>/Sync/pip-run/pip_run/__init__.py", line 14, in run
    raise SystemExit(launch.with_path(home, launch.infer_cmd(run_args)))
                     ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/<username>/Sync/pip-run/pip_run/launch.py", line 117, in with_path
    return subprocess.Popen(cmd, env=_setup_env(target)).wait()
                                     ~~~~~~~~~~^^^^^^^^
  File "/Users/<username>/Sync/pip-run/pip_run/launch.py", line 70, in _setup_env
    inject_sitecustomize(target)
    ~~~~~~~~~~~~~~~~~~~~^^^^^^^^
  File "/Users/<username>/Sync/pip-run/pip_run/launch.py", line 29, in inject_sitecustomize
    target.joinpath('sitecustomize.py').write_text(hook, encoding='utf-8')
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.13/3.13.3_1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/pathlib/_local.py", line 555, in write_text
    return PathBase.write_text(self, data, encoding, errors, newline)
           ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.13/3.13.3_1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/pathlib/_abc.py", line 651, in write_text
    with self.open(mode='w', encoding=encoding, errors=errors, newline=newline) as f:
         ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.13/3.13.3_1/Frameworks/Python.framework/Versions/3.13/lib/python3.13/pathlib/_local.py", line 537, in open
    return io.open(self, mode, buffering, encoding, errors, newline)
           ~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: "/Users/<username>/Library/Caches/pip run/e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855/sitecustomize.py"
```

My PR should fix this by always ensuring the cache dir exists before returning it. 