### PR TITLE
Allow a max age on persistent environments

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -272,7 +272,7 @@ equivalent to executing ``pip-run pydragon``.
 By default, the script will assemble the dependencies on each invocation,
 which may be inconvenient for a script. See `Environment Persistence
 <#Environment-Persistence>`_ for a technique to persist the assembled
-dependencies across invocations. One may inject ``PIP_RUN_MODE=persist``
+dependencies across invocations. One may inject ``PIP_RUN_RETENTION_STRATEGY=persist``
 in the shebang, but be aware that doing so breaks Windows portability.
 
 .. [2] ``.PY`` must exist in the PATHEXT for Python scripts to be executable. See `this documentation <https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_environment_variables?view=powershell-7.3#path-information>`_ for more background.
@@ -378,6 +378,13 @@ maintained for each combination of requirements specified.
 
 ``persist`` strategy can greatly improve startup performance at the expense of
 staleness and accumulated cruft.
+
+``persist`` also accepts a parameter "max age". Setting the max age will
+delete any cached environments older than the indicated age. For example,
+``PIP_RUN_RETENTION_STRATEGY=persist {"max age": "1 day"}`` (or
+``86400``) will retain the environment for only one day or
+``PIP_RUN_RETENTION_STRATEGY=persist {"max age": "6 months"}`` will
+do the same for half a year.
 
 Without ``PIP_RUN_RETENTION_STRATEGY=persist`` (or with ``=destroy``),
 ``pip-run`` will re-install dependencies every time a script runs, silently

--- a/mypy.ini
+++ b/mypy.ini
@@ -39,3 +39,7 @@ ignore_missing_imports = True
 # Avoid failures in examples/test-mongodb-covered-query
 [mypy-jaraco.mongodb.testing]
 ignore_missing_imports = True
+
+# jaraco/tempora#35
+[mypy-tempora]
+ignore_missing_imports = True

--- a/newsfragments/85.feature.rst
+++ b/newsfragments/85.feature.rst
@@ -1,1 +1,1 @@
-Implement support for max_age in persistent environments.
+Implement support for max_age in persistent environments. To set a max age on persistent environments, use ``PIP_RUN_RETENTION_STRATEGY=persist {"max age": "2 weeks"}``. Default is unchanged, but likely the default retention strategy will switch to ``persist {"max age": "1 day"}`` (or multiple days) in a future release.

--- a/newsfragments/85.feature.rst
+++ b/newsfragments/85.feature.rst
@@ -1,0 +1,1 @@
+Implement support for max_age in persistent environments.

--- a/pip_run/deps.py
+++ b/pip_run/deps.py
@@ -1,7 +1,5 @@
 import argparse
 import contextlib
-import importlib
-import os
 import pathlib
 import shutil
 import subprocess
@@ -9,6 +7,8 @@ import sys
 import types
 
 from jaraco.context import suppress
+
+from . import retention
 
 
 class Install(types.SimpleNamespace):
@@ -46,11 +46,6 @@ class Install(types.SimpleNamespace):
         True
         """
         return bool(self.requirement or self.package)
-
-
-def retention_strategy():
-    strategy = os.environ.get('PIP_RUN_RETENTION_STRATEGY') or 'destroy'
-    return importlib.import_module(f'.retention.{strategy}', package=__package__)
 
 
 @suppress(FileNotFoundError)
@@ -145,7 +140,7 @@ def default_quiet(cmd):
 
 @contextlib.contextmanager
 def load(*args):
-    with retention_strategy().context(args) as target:
+    with retention.strategy().context(args) as target:
         cmd = list(installer(target)) + default_quiet(args)
         if Install.parse(args) and empty(target):
             subprocess.check_call(cmd)

--- a/pip_run/deps.py
+++ b/pip_run/deps.py
@@ -140,7 +140,7 @@ def default_quiet(cmd):
 
 @contextlib.contextmanager
 def load(*args):
-    with retention.strategy().context(args) as target:
+    with retention.strategy()(args) as target:
         cmd = list(installer(target)) + default_quiet(args)
         if Install.parse(args) and empty(target):
             subprocess.check_call(cmd)

--- a/pip_run/retention/__init__.py
+++ b/pip_run/retention/__init__.py
@@ -1,0 +1,7 @@
+import importlib
+import os
+
+
+def strategy():
+    strategy = os.environ.get('PIP_RUN_RETENTION_STRATEGY') or 'destroy'
+    return importlib.import_module(f'.{strategy}', package=__package__)

--- a/pip_run/retention/__init__.py
+++ b/pip_run/retention/__init__.py
@@ -1,3 +1,4 @@
+import functools
 import importlib
 import json
 import os
@@ -35,4 +36,5 @@ def make_var(name):
 def strategy():
     spec = os.environ.get('PIP_RUN_RETENTION_STRATEGY') or 'destroy'
     strat = Strategy.resolve(spec)
-    return importlib.import_module(f'.{strat}', package=__package__)
+    module = importlib.import_module(f'.{strat}', package=__package__)
+    return functools.partial(module.context, **strat.params)

--- a/pip_run/retention/__init__.py
+++ b/pip_run/retention/__init__.py
@@ -1,7 +1,41 @@
 import importlib
 import os
+import re
+
+
+class Strategy(str):
+    params: dict[str, str]
+
+    @classmethod
+    def resolve(cls, spec):
+        """
+        Resolve a strategy spec to a strategy name and context params.
+
+        >>> Strategy.resolve('destroy')
+        'destroy'
+        >>> Strategy.resolve('persist').params
+        {}
+        >>> Strategy.resolve('persist; max-age=86400').params
+        {'max_age': '86400'}
+        >>> Strategy.resolve('persist; max age=86400; other=true').params
+        {'max_age': '86400', 'other': 'true'}
+        """
+        name, sep, rest = spec.partition(';')
+        strat = cls(name)
+        strat.params = dict(filter(None, map(clean_param, rest.split(';'))))
+        return strat
+
+
+def make_var(name):
+    return re.sub(r'[ -]+', '_', name.strip())
+
+
+def clean_param(pair):
+    name, sep, value = pair.partition('=')
+    return name and (make_var(name), value and value.strip())
 
 
 def strategy():
-    strategy = os.environ.get('PIP_RUN_RETENTION_STRATEGY') or 'destroy'
-    return importlib.import_module(f'.{strategy}', package=__package__)
+    spec = os.environ.get('PIP_RUN_RETENTION_STRATEGY') or 'destroy'
+    strat = Strategy.resolve(spec)
+    return importlib.import_module(f'.{strat}', package=__package__)

--- a/pip_run/retention/persist.py
+++ b/pip_run/retention/persist.py
@@ -1,5 +1,7 @@
 import contextlib
 import hashlib
+import shutil
+import time
 
 import platformdirs
 
@@ -49,5 +51,13 @@ def cache_key(args):
 
 
 @contextlib.contextmanager
-def context(args):
-    yield paths.user_cache_path.joinpath(cache_key(args))
+def context(args, max_age=float('inf')):
+    path = paths.user_cache_path.joinpath(cache_key(args))
+    yield clean_if_older(path, max_age)
+
+
+def clean_if_older(path, max_age):
+    with contextlib.suppress(FileNotFoundError):
+        age = time.time() - path.stat().st_mtime
+        age > max_age and shutil.rmtree(path)
+    return path

--- a/pip_run/retention/persist.py
+++ b/pip_run/retention/persist.py
@@ -1,9 +1,14 @@
+from __future__ import annotations
+
 import contextlib
+import datetime
+import functools
 import hashlib
 import shutil
 import time
 
 import platformdirs
+import tempora
 
 from .. import deps
 
@@ -53,11 +58,39 @@ def cache_key(args):
 @contextlib.contextmanager
 def context(args, max_age=float('inf')):
     path = paths.user_cache_path.joinpath(cache_key(args))
-    yield clean_if_older(path, max_age)
+    yield clean_if_older(path, parse_duration(max_age))
 
 
 def clean_if_older(path, max_age):
     with contextlib.suppress(FileNotFoundError):
-        age = time.time() - path.stat().st_mtime
+        age = datetime.timedelta(seconds=time.time() - path.stat().st_mtime)
         age > max_age and shutil.rmtree(path)
     return path
+
+
+class Eternity:
+    def __gt__(self, other: datetime.timedelta):
+        return True
+
+    def __repr__(self):
+        return self.__class__.__name__
+
+
+@functools.singledispatch
+def parse_duration(input: str | float):
+    """
+    >>> parse_duration("2 weeks")
+    datetime.timedelta(days=14)
+    >>> parse_duration(30)
+    datetime.timedelta(seconds=30)
+    >>> parse_duration(float('inf'))
+    Eternity
+    """
+    if input == float('inf'):
+        return Eternity()
+    return datetime.timedelta(seconds=input)  # type: ignore[arg-type]
+
+
+@parse_duration.register
+def _(input: str):
+    return tempora.parse_timedelta(input)

--- a/pip_run/retention/persist.py
+++ b/pip_run/retention/persist.py
@@ -69,6 +69,12 @@ def clean_if_older(path, max_age):
 
 
 class Eternity:
+    """
+    >>> import random
+    >>> Eternity() > datetime.timedelta(random.randint(2**31))
+    True
+    """
+
     def __gt__(self, other: datetime.timedelta):
         return True
 

--- a/pip_run/retention/persist.py
+++ b/pip_run/retention/persist.py
@@ -62,6 +62,18 @@ def context(args, max_age=float('inf')):
 
 
 def clean_if_older(path, max_age):
+    """
+    >>> tmp_path = getfixture('tmp_path') / 'dir'
+    >>> tmp_path.mkdir()
+    >>> freezer = getfixture('freezer')
+    >>> freezer.move_to('2076-05-07')
+    >>> _ = clean_if_older(tmp_path, Eternity())
+    >>> tmp_path.exists()
+    True
+    >>> _ = clean_if_older(tmp_path, datetime.timedelta(days=5))
+    >>> tmp_path.exists()
+    False
+    """
     with contextlib.suppress(FileNotFoundError):
         age = datetime.timedelta(seconds=time.time() - path.stat().st_mtime)
         age > max_age and shutil.rmtree(path)
@@ -71,12 +83,15 @@ def clean_if_older(path, max_age):
 class Eternity:
     """
     >>> import random
-    >>> Eternity() > datetime.timedelta(random.randint(2**31))
+    >>> Eternity() > datetime.timedelta(seconds=random.randint(0, 2**31))
     True
     """
 
     def __gt__(self, other: datetime.timedelta):
         return True
+
+    def __lt__(self, other: datetime.timedelta):
+        return False
 
     def __repr__(self):
         return self.__class__.__name__

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ test = [
 	"jaraco.path",
 	"jaraco.test >= 5.3",
 	"flit-core",
+	"pytest-freezer",
 ]
 
 doc = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
 	"jaraco.functools >= 3.7",
 	"jaraco.env",
 	"coherent.deps",
+	"tempora",
 ]
 dynamic = ["version"]
 

--- a/tests/test_deps.py
+++ b/tests/test_deps.py
@@ -1,6 +1,6 @@
 import pytest
 
-import pip_run.deps as deps
+from pip_run import deps
 
 
 @pytest.mark.usefixtures('retention_strategy')
@@ -20,10 +20,3 @@ class TestLoad:
         """
         with deps.load('-q'):
             pass
-
-
-@pytest.mark.usefixtures('retention_strategy')
-def test_target_retention_context():
-    """Verify a target exists or can be created."""
-    with deps.retention_strategy().context([]) as target:
-        target.mkdir(exist_ok=True)

--- a/tests/test_retention.py
+++ b/tests/test_retention.py
@@ -1,0 +1,10 @@
+import pytest
+
+from pip_run import retention
+
+
+@pytest.mark.usefixtures('retention_strategy')
+def test_target_retention_context():
+    """Verify a target exists or can be created."""
+    with retention.strategy().context([]) as target:
+        target.mkdir(exist_ok=True)

--- a/tests/test_retention.py
+++ b/tests/test_retention.py
@@ -6,5 +6,5 @@ from pip_run import retention
 @pytest.mark.usefixtures('retention_strategy')
 def test_target_retention_context():
     """Verify a target exists or can be created."""
-    with retention.strategy().context([]) as target:
+    with retention.strategy()([]) as target:
         target.mkdir(exist_ok=True)


### PR DESCRIPTION
- **Move retention logic into its own namespace.**
- **Provide a syntax for specifying parameters to the strategy.**
- **Rely on JSON syntax for params.**
- **Pass any parameters to the context.**
- **Implement support for max_age in persistent environments.**
- **Added support for nice timedelta parsing in max age.**
- **Update documentation pertinent to the change.**

Closes #85
